### PR TITLE
Add update functionality

### DIFF
--- a/internal/handlers/activity.go
+++ b/internal/handlers/activity.go
@@ -79,3 +79,71 @@ func (h *ActivityHandler) GetActivity(c *gin.Context) {
 		Data:    activity,
 	})
 }
+
+func (h *ActivityHandler) UpdateActivity(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id")) // Convert :id parameter to integer
+	if err != nil {
+		// Return a 400 Bad Request response if the ID is invalid
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Success: false,
+			Error:   "Invalid activity ID",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	var req models.UpdateActivityRequest
+	if err := c.ShouldBindJSON(&req); err != nil { // If the request body is invalid (invalid JSON)
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Success: false,
+			Error:   err.Error(),
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	var activity models.Activity
+	if err := h.db.First(&activity, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Success: false,
+			Error:   "Activity not found",
+			Code:    http.StatusNotFound,
+		})
+		return
+	}
+
+	if req.ActivityType == nil && req.DurationInMinutes == nil && req.CaloriesBurned == nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Success: false,
+			Error:   "Invalid request body",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	// Apply updates
+	if req.ActivityType != nil {
+		activity.ActivityType = *req.ActivityType
+	}
+	if req.DurationInMinutes != nil {
+		activity.DurationInMinutes = *req.DurationInMinutes
+	}
+	if req.CaloriesBurned != nil {
+		activity.CaloriesBurned = *req.CaloriesBurned
+	}
+
+	if err := h.db.Save(&activity).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Success: false,
+			Error:   err.Error(),
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, models.APIResponse{
+		Success: true,
+		Message: "Activity updated successfully",
+		Data:    activity,
+	})
+}

--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -7,3 +7,9 @@ type Activity struct {
 	DurationInMinutes int    `gorm:"column:duration_in_minutes;not null" json:"duration_in_minutes"`
 	CaloriesBurned    int    `gorm:"column:calories_burned;not null" json:"calories_burned"`
 }
+
+type UpdateActivityRequest struct {
+	ActivityType      *string `gorm:"column:activity_type;type:varchar(100);not null" json:"activity_type"`
+	DurationInMinutes *int    `gorm:"column:duration_in_minutes;not null" json:"duration_in_minutes"`
+	CaloriesBurned    *int    `gorm:"column:calories_burned;not null" json:"calories_burned"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -32,6 +32,7 @@ func SetupRoutes(router *gin.Engine, healthHandler *handlers.HealthHandler, user
 		{
 			activity.GET("/", activityHandler.GetActivities)
 			activity.GET("/:id", activityHandler.GetActivity)
+			activity.PUT("/:id", activityHandler.UpdateActivity)
 		}
 	}
 


### PR DESCRIPTION
This pull request adds support for updating an existing activity record via a new API endpoint. The main changes include introducing a new handler for updating activities, defining a request model for partial updates, and registering the new route.

**API feature addition:**

* Added `UpdateActivity` handler to `ActivityHandler` in `internal/handlers/activity.go`, which validates the request, checks for the existence of the activity, applies partial updates, and returns appropriate responses.
* Registered the new `PUT /activities/:id` route in `internal/routes/routes.go` to allow clients to update activity records.

**Model changes:**

* Introduced `UpdateActivityRequest` struct in `internal/models/activity.go` to support partial updates of `ActivityType`, `DurationInMinutes`, and `CaloriesBurned` fields.